### PR TITLE
[PrettyPrinter] Decrease digits for holdings and ref_market_value

### DIFF
--- a/octobot_commons/pretty_printer.py
+++ b/octobot_commons/pretty_printer.py
@@ -149,11 +149,11 @@ def _get_markdown_pretty_portfolio_row(
     :return: the portfolio row adapted for a markdown format
     """
     str_currency = "{:<4}".format(currency)
-    str_holdings = "{:<12}".format(get_min_string_from_number(holdings, max_digits=6))
+    str_holdings = "{:<12}".format(get_min_string_from_number(holdings, max_digits=4))
     str_ref_market_value = "{:<12}".format("")
     if ref_market:
         str_ref_market_value = "{:<12}".format(
-            get_min_string_from_number(ref_market_value) if ref_market_value else ""
+            get_min_string_from_number(ref_market_value, max_digits=2) if ref_market_value else ""
         )
     return f"{str_currency} {str_holdings} {str_ref_market_value}"
 


### PR DESCRIPTION
For readability in telegram output decrease the max digits for holdings to 4 and for the reference market value to 2